### PR TITLE
reduce csv import memory usage #76

### DIFF
--- a/common/strings_test.go
+++ b/common/strings_test.go
@@ -1,0 +1,66 @@
+package common
+
+import "testing"
+
+func SpecialLettersEquals(bs []byte) bool {
+	bs1 := SpecialLettersUsingMySQL(bs)
+	bs2 := SpecialLettersUsingMySQLOld(bs)
+	return bs2 == bs1
+}
+
+func TestSpecialLettersEquals(t *testing.T) {
+
+	bs1 := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		bs1[i] = byte(i)
+	}
+
+	type args struct {
+		bs []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			args: args{bs: bs1},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SpecialLettersEquals(tt.args.bs); got != tt.want {
+				t.Errorf("SpecialLettersEquals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkSpecialLettersUsingMySQLOld(b *testing.B) {
+	bs1 := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		bs1[i] = byte(i)
+	}
+	// Call b.ReportAllocs() to enable memory allocation tracking
+	b.ReportAllocs()
+
+	// Run the function b.N times
+	for i := 0; i < b.N; i++ {
+		SpecialLettersUsingMySQLOld(bs1)
+	}
+}
+
+func BenchmarkSpecialLettersUsingMySQLNew(b *testing.B) {
+	bs1 := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		bs1[i] = byte(i)
+	}
+	// Call b.ReportAllocs() to enable memory allocation tracking
+	b.ReportAllocs()
+
+	// Run the function b.N times
+	for i := 0; i < b.N; i++ {
+		SpecialLettersUsingMySQL(bs1)
+	}
+}

--- a/module/migrate/csv/oracle/o2t/table.go
+++ b/module/migrate/csv/oracle/o2t/table.go
@@ -40,7 +40,7 @@ type Rows struct {
 	DBCharsetS   string
 	DBCharsetT   string
 	ColumnNameS  []string
-	ReadChannel  chan []map[string]string
+	ReadChannel chan [][]string
 	WriteChannel chan string
 }
 
@@ -48,7 +48,7 @@ func NewRows(ctx context.Context, syncMeta meta.FullSyncMeta,
 	oracle *oracle.Oracle, cfg *config.Config, columnNameS []string, sourceDBCharset string) *Rows {
 
 	writeChannel := make(chan string, common.ChannelBufferSize)
-	readChannel := make(chan []map[string]string, common.ChannelBufferSize)
+	readChannel := make(chan [][]string, common.ChannelBufferSize)
 
 	return &Rows{
 		Ctx:          ctx,
@@ -92,7 +92,7 @@ func (t *Rows) ReadData() error {
 		execQuerySQL = common.StringsBuilder(`SELECT `, columnDetailS, ` FROM `, t.SyncMeta.SchemaNameS, `.`, t.SyncMeta.TableNameS, ` WHERE `, t.SyncMeta.ChunkDetailS)
 	}
 
-	err = t.Oracle.GetOracleTableRowsDataCSV(execQuerySQL, t.DBCharsetS, t.DBCharsetT, t.Cfg, t.ReadChannel)
+	err = t.Oracle.GetOracleTableRowsDataCSV(execQuerySQL, t.DBCharsetS, t.DBCharsetT, t.Cfg, t.ReadChannel, t.ColumnNameS)
 	if err != nil {
 		// 通道关闭
 		close(t.ReadChannel)
@@ -117,21 +117,12 @@ func (t *Rows) ReadData() error {
 func (t *Rows) ProcessData() error {
 
 	for dataC := range t.ReadChannel {
-		for _, dMap := range dataC {
-			// 按字段名顺序遍历获取对应值
-			var (
-				rowsTMP []string
-			)
-			for _, column := range t.ColumnNameS {
-				if val, ok := dMap[column]; ok {
-					rowsTMP = append(rowsTMP, val)
-				}
-			}
-			if len(rowsTMP) != len(t.ColumnNameS) {
+		for _, dSlice := range dataC {
+			if len(dSlice) != len(t.ColumnNameS) {
 				return fmt.Errorf("source schema table column counts vs data counts isn't match")
 			} else {
 				// csv 文件行数据输入
-				t.WriteChannel <- common.StringsBuilder(exstrings.Join(rowsTMP, t.Cfg.CSVConfig.Separator), t.Cfg.CSVConfig.Terminator)
+				t.WriteChannel <- common.StringsBuilder(exstrings.Join(dSlice, t.Cfg.CSVConfig.Separator), t.Cfg.CSVConfig.Terminator)
 			}
 		}
 	}


### PR DESCRIPTION
## 新增/修改函数
1. ByteToString:  替代string([]byte)生成字符串，效率更高，参考文章 https://segmentfault.com/a/1190000037679588
2. SpecialLettersEquals：重构，并通过测试用例验证代码行为一致，执行效率更高，见strings_test.go
3. GetOracleTableRowsDataCSV：将装载行数据的对象，从map改为slice；替换不必要的fmt.Sprintf；减少内存开销